### PR TITLE
Fix example file name path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project aims to help ensuring you or your organizations repositories' settings and branch protection rules conform to the standard you have set up.
 
-The standard is configured in a single json file (see `example.config.json`).
+The standard is configured in a single json file (see `config.example.json`).
 
 ## Usage
 


### PR DESCRIPTION
The example file in the repo was `config.example.json` but referred to as `example.config.json` in the README

This PR fixes the reference in the README to match reality.

Fixes #210
